### PR TITLE
Remove keywords internal

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wikirest
 Title: Get data from the Wikimedia REST API
-Version: 0.0.0.9014
+Version: 0.0.0.9015
 Authors@R: 
     person("Judith", "Bourque", , "info@clessn.ca", role = c("aut", "cre"))
 Description: Get data from the Wikimedia REST API.

--- a/R/error.R
+++ b/R/error.R
@@ -4,7 +4,6 @@
 #'
 #' @param parameters List or vector of parameters.
 #'
-#' @keywords internal
 #' @noRd
 #'
 #' @return Error message if parameters missing.

--- a/R/metrics.R
+++ b/R/metrics.R
@@ -2,7 +2,6 @@
 #'
 #' `r lifecycle::badge('experimental')`
 #'
-#' @keywords internal
 #' @noRd
 #'
 #' @return A modified HTTP request.

--- a/R/pageviews.R
+++ b/R/pageviews.R
@@ -2,7 +2,6 @@
 #'
 #' `r lifecycle::badge('experimental')`
 #'
-#' @keywords internal
 #' @noRd
 #'
 #' @return A modified HTTP request.

--- a/R/request.R
+++ b/R/request.R
@@ -2,7 +2,6 @@
 #'
 #' `r lifecycle::badge('experimental')`
 #'
-#' @keywords internal
 #' @noRd
 #'
 #' @return A modified HTTP request.
@@ -17,7 +16,6 @@ create_req <- function() {
 #'
 #' @param req A HTTP request.
 #'
-#' @keywords internal
 #' @noRd
 #'
 #' @return A modified HTTP request.


### PR DESCRIPTION
Adding `@keywords internal` can seem intuitive, but it's redundant as there's no `.Rd` file and the function isn't available to users as `@export` isn't used.